### PR TITLE
Optimized Dockerfiles to reduce number of layers

### DIFF
--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -1,14 +1,14 @@
 FROM centos:7
 MAINTAINER Adam Bien, adam-bien.com
-RUN yum update -y
-RUN yum clean all
-RUN yum -y install wget
-RUN yum -y install unzip
-RUN yum -y install tar
-RUN yum -y install gettext
-RUN yum -y install openssh-server
-RUN yum -y install openssh-clients
-RUN mkdir /var/run/sshd
-RUN /usr/bin/ssh-keygen -A
-RUN yum -y install java-1.8.0-openjdk-devel
+RUN yum update -y && \
+    yum clean all && \
+    yum -y install wget && \
+    yum -y install unzip && \
+    yum -y install tar && \
+    yum -y install gettext && \
+    yum -y install openssh-server && \
+    yum -y install openssh-clients && \
+    mkdir /var/run/sshd && \
+    /usr/bin/ssh-keygen -A && \
+    yum -y install java-1.8.0-openjdk-devel
 ENV PATH "$PATH":/${JAVA_HOME}/bin:.:

--- a/payara-ping/Dockerfile
+++ b/payara-ping/Dockerfile
@@ -1,9 +1,13 @@
-FROM airhacks/payara
-MAINTAINER Adam Bien, adam-bien.com
-ADD start.sh .
-RUN chmod u+x start.sh
 # For more information about ping see: https://github.com/AdamBien/ping/
-ADD ping.war .
+FROM airhacks/payara
+
+MAINTAINER Adam Bien, adam-bien.com
+
+COPY ping.war start.sh ./
+
+RUN chmod u+x start.sh
+
 ENTRYPOINT ./start.sh
+
 EXPOSE 8080 5701 4848
 

--- a/payara/Dockerfile
+++ b/payara/Dockerfile
@@ -1,11 +1,15 @@
 FROM airhacks/java
+
 MAINTAINER Adam Bien, adam-bien.com
-ENV PAYARA_ARCHIVE payara41
-ENV DOMAIN_NAME domain1
-ENV INSTALL_DIR /opt
-RUN curl -o ${INSTALL_DIR}/${PAYARA_ARCHIVE}.zip -L http://bit.ly/1Gm0GIw
-RUN unzip ${INSTALL_DIR}/${PAYARA_ARCHIVE}.zip -d /opt
-ENV PAYARA_HOME ${INSTALL_DIR}/payara41/glassfish
-ENV EXEC ${PAYARA_HOME}/bin
-ENV DEPLOYMENT_DIR ${PAYARA_HOME}/domains/${DOMAIN_NAME}/autodeploy/
+
+ENV PAYARA_ARCHIVE=payara41 \
+    DOMAIN_NAME=domain1 \
+    INSTALL_DIR=/opt \
+    PAYARA_HOME=/opt/payara41/glassfish \
+    EXEC=/opt/payara41/glassfish/bin \
+    DEPLOYMENT_DIR=/opt/payara41/glassfish/domains/domain1/autodeploy/
+
+RUN curl -o ${INSTALL_DIR}/${PAYARA_ARCHIVE}.zip -L http://bit.ly/1Gm0GIw && \
+    unzip ${INSTALL_DIR}/${PAYARA_ARCHIVE}.zip -d /opt 
+
 EXPOSE 4848 8009 8080 8181


### PR DESCRIPTION
use one single ENV and one single RUN instead, to reduce number of layers. Use COPY instead of ADD for files you don't intend to extract, and as many files as you want, if they will end up being in the same directory.
