### PR TITLE
Tomcat 8.033 is archived, redirected to 8.0.39

### DIFF
--- a/tomcat/Dockerfile
+++ b/tomcat/Dockerfile
@@ -1,9 +1,9 @@
 FROM airhacks/java
 MAINTAINER Adam Bien, adam-bien.com
-ENV ARCHIVE apache-tomcat-8.0.33
+ENV ARCHIVE apache-tomcat-8.0.39
 ENV INSTALL_DIR /opt
 ENV SERVER_HOME ${INSTALL_DIR}/${ARCHIVE}
-RUN curl -o ${SERVER_HOME}.zip -L http://apache.mirror.iphh.net/tomcat/tomcat-8/v8.0.33/bin/apache-tomcat-8.0.33.zip
+RUN curl -o ${SERVER_HOME}.zip -L http://apache.mirror.iphh.net/tomcat/tomcat-8/v8.0.39/bin/apache-tomcat-8.0.39.zip
 RUN unzip ${SERVER_HOME}.zip -d /opt
 RUN chmod a+x ${SERVER_HOME}/bin/catalina.sh
 ENV DEPLOYMENT_DIR ${SERVER_HOME}/webapps/


### PR DESCRIPTION
Tomcat download link redirected to 8.0.39 as release 8.0.33 was archived. If it is of importance to keep version 8.0.33 working, then following link could be used instead: https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.33/bin/apache-tomcat-8.0.33.zip