### PR TITLE
OpenLiberty updates & improvements

### DIFF
--- a/openliberty-kernel/Dockerfile
+++ b/openliberty-kernel/Dockerfile
@@ -2,16 +2,20 @@
 
 FROM airhacks/java
 MAINTAINER Adam Bien, adam-bien.com
-ENV RELEASE 2017-09-16_2214
-ENV VERSION 17.0.0.3-RC
+ENV VERSION 17.0.0.3
+ENV SHA 528e393e0b240ebbedb91d25402e22297c6d56ec
 ENV INSTALL_DIR /opt/ibm
 
 # Download OpenLiberty
 ENV OPENLIBERTY_HOME ${INSTALL_DIR}/openliberty-${VERSION}
 ENV DEPLOYMENT_DIR ${OPENLIBERTY_HOME}/standalone/deployments/
-RUN curl -O https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/${RELEASE}/openliberty-${VERSION}.zip \
-    && unzip openliberty-${VERSION}.zip -d ${INSTALL_DIR} \
-    && rm openliberty-${VERSION}.zip
+RUN curl -O https://repo1.maven.org/maven2/io/openliberty/openliberty-runtime/${VERSION}/openliberty-runtime-${VERSION}.zip \
+    && echo "$SHA openliberty-runtime-${VERSION}.zip" > openliberty-runtime-${VERSION}.zip.sha1 \
+    && sha1sum -c openliberty-runtime-${VERSION}.zip.sha1 \
+    && unzip -q openliberty-runtime-${VERSION}.zip -d ${INSTALL_DIR} \
+    && rm openliberty-runtime-${VERSION}.zip \
+    && rm openliberty-runtime-${VERSION}.zip.sha1
+
 ENV PATH=/opt/ibm/wlp/bin:$PATH
 
 # Set Path Shortcuts

--- a/openliberty-microprofile-ping/Dockerfile
+++ b/openliberty-microprofile-ping/Dockerfile
@@ -2,5 +2,4 @@
 
 FROM airhacks/openliberty-microprofile
 MAINTAINER Adam Bien, adam-bien.com
-ENV DEPLOYMENT_DIR /config/dropins/
 COPY ping.war ${DEPLOYMENT_DIR}

--- a/openliberty-microprofile/Dockerfile
+++ b/openliberty-microprofile/Dockerfile
@@ -1,4 +1,5 @@
 FROM airhacks/openliberty-kernel
 MAINTAINER Adam Bien, adam-bien.com
 
+ENV DEPLOYMENT_DIR /config/dropins/
 COPY server.xml /config/

--- a/openliberty-webprofile7-ping/Dockerfile
+++ b/openliberty-webprofile7-ping/Dockerfile
@@ -2,5 +2,4 @@
 
 FROM airhacks/openliberty-webprofile7
 MAINTAINER Adam Bien, adam-bien.com
-ENV DEPLOYMENT_DIR /config/dropins/
 COPY ping.war ${DEPLOYMENT_DIR}

--- a/openliberty-webprofile7/Dockerfile
+++ b/openliberty-webprofile7/Dockerfile
@@ -3,4 +3,5 @@
 FROM airhacks/openliberty-kernel
 MAINTAINER Adam Bien, adam-bien.com
 
+ENV DEPLOYMENT_DIR /config/dropins/
 COPY server.xml /config/


### PR DESCRIPTION
- Updated OpenLiberty version to latest (17.0.0.3)
- Changed download repository to maven (in accordance to official image)
- Introduced SHA1 check for downloaded zip bundle
- Moved DEPLOYMENT_DIR env variable one level up the stack